### PR TITLE
Add docs-based MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,62 @@
 # MCPOV_Test
+
+This repository includes `ov_function_counts.csv` with the canonical OmicVerse function names. The steps below show how to expose documentation for these functions via a minimal MCP-compliant server without using embeddings.
+
+## 1. Install prerequisites
+
+```bash
+pip install fastapi uvicorn mcp-agent
+```
+
+## 2. Clone the OmicVerse repository and extract docs
+
+```bash
+git clone https://github.com/Starlitnightly/omicverse.git
+python build_function_docs.py omicverse
+```
+
+This creates `function_docs.json` containing the docstring for every function found in `ov_function_counts.csv`.
+
+## 3. Start the doc server
+
+```bash
+uvicorn doc_server:app --host 0.0.0.0 --port 8000
+```
+
+The FastAPI server exposes an OpenAPI specification compatible with Model Context Protocol. The `doc` tool returns the stored docstring for a given function name.
+
+## 4. Query via an agent
+
+`agent_runner.py` demonstrates how a lastmile `mcp-agent` can retrieve a docstring:
+
+```python
+import asyncio
+from mcp_agent.agents.agent import Agent
+from mcp_agent.workflows.llm.augmented_llm_openai import OpenAIAugmentedLLM
+
+DOC_SERVER = "http://localhost:8000"
+
+async def main():
+    bot = Agent(
+        name="omics_doc_bot",
+        instruction=(
+            "Return the OmicVerse docstring for the requested function; respond with 'Not documented' if missing."),
+        server_names=[DOC_SERVER]
+    )
+
+    async with bot:
+        llm = await bot.attach_llm(OpenAIAugmentedLLM)
+        resp = await llm.generate_str("Explain ov.utils.cluster")
+        print(resp)
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+Run the agent with:
+
+```bash
+OPENAI_API_KEY=... python agent_runner.py
+```
+
+This workflow serves exact documentation for each function using only the names listed in `ov_function_counts.csv`.

--- a/agent_runner.py
+++ b/agent_runner.py
@@ -1,0 +1,21 @@
+import asyncio
+from mcp_agent.agents.agent import Agent
+from mcp_agent.workflows.llm.augmented_llm_openai import OpenAIAugmentedLLM
+
+DOC_SERVER = "http://localhost:8000"
+
+async def main():
+    bot = Agent(
+        name="omics_doc_bot",
+        instruction=(
+            "Return the OmicVerse docstring for the requested function; respond with 'Not documented' if missing."),
+        server_names=[DOC_SERVER]
+    )
+
+    async with bot:
+        llm = await bot.attach_llm(OpenAIAugmentedLLM)
+        resp = await llm.generate_str("Explain ov.utils.cluster")
+        print(resp)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/build_function_docs.py
+++ b/build_function_docs.py
@@ -1,0 +1,38 @@
+import ast
+import csv
+import json
+import sys
+import textwrap
+from pathlib import Path
+
+repo_root = Path(sys.argv[1] if len(sys.argv) > 1 else "omicverse")
+csv_path = Path("ov_function_counts.csv")
+output_path = Path("function_docs.json")
+
+docs = {}
+with csv_path.open() as f:
+    reader = csv.DictReader(line for line in f if line.strip())
+    for row in reader:
+        func = row["Function"]
+        parts = func.split(".")
+        if len(parts) < 3 or parts[0] != "ov":
+            continue
+        module = parts[1]
+        name = parts[2]
+        search_dir = repo_root / module
+        doc = None
+        if search_dir.exists():
+            for py in search_dir.rglob("*.py"):
+                tree = ast.parse(py.read_text(encoding="utf-8"))
+                for node in ast.walk(tree):
+                    if isinstance(node, ast.FunctionDef) and node.name == name:
+                        doc = ast.get_docstring(node) or ""
+                        doc = textwrap.dedent(doc).strip()
+                        break
+                if doc is not None:
+                    break
+        docs[func] = doc or ""
+
+with output_path.open("w", encoding="utf-8") as f:
+    json.dump(docs, f, indent=2, ensure_ascii=False)
+print(f"Saved {len(docs)} docs to {output_path}")

--- a/doc_server.py
+++ b/doc_server.py
@@ -1,0 +1,18 @@
+from fastapi import FastAPI, HTTPException
+import json
+import os
+
+DATA_FILE = os.getenv("DOCS_FILE", "function_docs.json")
+
+with open(DATA_FILE, encoding="utf-8") as f:
+    DOCS = json.load(f)
+
+app = FastAPI(title="OmicVerse Function Docs", version="0.1.0")
+
+@app.get("/doc")
+async def get_doc(function: str):
+    """Return the stored docstring for a function name."""
+    doc = DOCS.get(function)
+    if not doc:
+        raise HTTPException(status_code=404, detail="Function not found")
+    return {"function": function, "doc": doc}


### PR DESCRIPTION
## Summary
- rewrite README with instructions for an embedding-free MCP server
- script to build function doc mapping from OmicVerse source
- minimal FastAPI server exposing doc retrieval tool
- update agent example to query new server
- fix CSV parsing for blank lines

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install fastapi uvicorn mcp-agent -q`
- `python build_function_docs.py omv_test_repo` *(executed successfully)*

------
https://chatgpt.com/codex/tasks/task_e_687dfea97c608326afa66b55034e4338