### PR TITLE
Add custom OpenAI base URL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,4 +59,10 @@ Run the agent with:
 OPENAI_API_KEY=... python agent_runner.py
 ```
 
+To use a local OpenAI-compatible endpoint such as Ollama, specify the API base URL:
+
+```bash
+OPENAI_API_KEY=dummy OPENAI_BASE_URL=http://localhost:11434/v1 python agent_runner.py
+```
+
 This workflow serves exact documentation for each function using only the names listed in `ov_function_counts.csv`.

--- a/agent_runner.py
+++ b/agent_runner.py
@@ -1,15 +1,32 @@
 import asyncio
+import os
 from mcp_agent.agents.agent import Agent
 from mcp_agent.workflows.llm.augmented_llm_openai import OpenAIAugmentedLLM
+from mcp_agent.config import Settings, OpenAISettings
+from mcp_agent.core.context import initialize_context
 
 DOC_SERVER = "http://localhost:8000"
 
+
 async def main():
+    cfg = Settings(
+        openai=OpenAISettings(
+            api_key=os.getenv("OPENAI_API_KEY"),
+            base_url=(
+                os.getenv("OPENAI_BASE_URL")
+                or os.getenv("OPENAI_API_BASE")
+            ),
+        )
+    )
+    context = await initialize_context(cfg)
     bot = Agent(
         name="omics_doc_bot",
         instruction=(
-            "Return the OmicVerse docstring for the requested function; respond with 'Not documented' if missing."),
-        server_names=[DOC_SERVER]
+            "Return the OmicVerse docstring for the requested function; "
+            "respond with 'Not documented' if missing."
+        ),
+        server_names=[DOC_SERVER],
+        context=context,
     )
 
     async with bot:

--- a/doc_server.py
+++ b/doc_server.py
@@ -9,6 +9,7 @@ with open(DATA_FILE, encoding="utf-8") as f:
 
 app = FastAPI(title="OmicVerse Function Docs", version="0.1.0")
 
+
 @app.get("/doc")
 async def get_doc(function: str):
     """Return the stored docstring for a function name."""


### PR DESCRIPTION
## Summary
- allow setting OpenAI-compatible endpoints by reading `OPENAI_BASE_URL`
- initialize MCP context with these settings in `agent_runner.py`
- mention how to run the agent against Ollama in README
- address flake8 warnings in `doc_server.py`

## Testing
- `python -m py_compile agent_runner.py build_function_docs.py doc_server.py`
- `flake8 .`

------
https://chatgpt.com/codex/tasks/task_e_687e0b29aa8083268dcb10acde5709c6